### PR TITLE
Profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml
+/.idea/dictionaries
 .DS_Store
 /build
 /captures
 .externalNativeBuild
+.idea/assetWizardSettings.xml
+.idea/caches/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ChatActivity" android:label="Chat">
+        <activity android:name=".ChatActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,14 +10,15 @@
         android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ChatActivity">
+        <activity android:name=".ChatActivity" android:label="Chat">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".SignActivity"/>
+        <activity android:name=".SignActivity" />
+        <activity android:name=".ProfileActivity" android:label="Profile" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/cid/bot/ChatActivity.kt
+++ b/app/src/main/java/com/cid/bot/ChatActivity.kt
@@ -3,10 +3,13 @@ package com.cid.bot
 import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 
 class ChatActivity : AppCompatActivity() {
     companion object {
         const val REQUEST_SIGN_IN = 101
+        const val REQUEST_PROFILE = 102
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +28,21 @@ class ChatActivity : AppCompatActivity() {
                 }
             }
             else -> super.onActivityResult(requestCode, resultCode, data)
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_chat, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.mIprofile -> {
+                startActivityForResult(Intent(this, ProfileActivity::class.java), REQUEST_PROFILE)
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 }

--- a/app/src/main/java/com/cid/bot/ChatActivity.kt
+++ b/app/src/main/java/com/cid/bot/ChatActivity.kt
@@ -1,5 +1,6 @@
 package com.cid.bot
 
+import android.app.Activity
 import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
@@ -16,6 +17,10 @@ class ChatActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_chat)
 
+        requestSignIn()
+    }
+
+    private fun requestSignIn() {
         startActivityForResult(Intent(this, SignActivity::class.java), REQUEST_SIGN_IN)
     }
 
@@ -25,6 +30,11 @@ class ChatActivity : AppCompatActivity() {
                 when (resultCode) {
                     RESULT_CANCELED -> finish()
                     RESULT_OK -> {} // TODO
+                }
+            }
+            REQUEST_PROFILE -> {
+                when (resultCode) {
+                    Activity.RESULT_CANCELED -> requestSignIn()
                 }
             }
             else -> super.onActivityResult(requestCode, resultCode, data)

--- a/app/src/main/java/com/cid/bot/Network.kt
+++ b/app/src/main/java/com/cid/bot/Network.kt
@@ -16,10 +16,7 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.http.Field
-import retrofit2.http.FormUrlEncoded
-import retrofit2.http.PATCH
-import retrofit2.http.POST
+import retrofit2.http.*
 
 private val interceptor = object : Interceptor {
     var authToken = ""
@@ -64,6 +61,12 @@ interface ChatBotAPI {
     fun changePassword(@Field("old_password") oldPassword: String,
                        @Field("new_password") newPassword: String
     ): Observable<Response<JsonObject>>
+
+    @GET("/chatbot/my-info")
+    fun loadMyInfo(): Observable<Response<Muser>>
+
+    @PATCH("/chatbot/my-info/")
+    fun saveMyInfo(@Body muser: Muser): Observable<Response<Muser>>
 }
 
 object NetworkManager {

--- a/app/src/main/java/com/cid/bot/Network.kt
+++ b/app/src/main/java/com/cid/bot/Network.kt
@@ -7,6 +7,7 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import org.json.JSONArray
 import org.json.JSONException
@@ -17,20 +18,26 @@ import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 
+private val interceptor = object : Interceptor {
+    var authToken = ""
+
+    override fun intercept(chain: Interceptor.Chain): okhttp3.Response {
+        val original = chain.request()
+        val builder = original.newBuilder().header("Authorization", authToken)
+        val request = builder.build()
+        return chain.proceed(request)
+    }
+}
 val API: ChatBotAPI = Retrofit.Builder()
         .baseUrl("http://10.0.2.2:8000")    /* development environment */
         .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
         .addConverterFactory(GsonConverterFactory.create(
                 GsonBuilder().serializeNulls().create()
         ))
-        .client(OkHttpClient.Builder().addInterceptor { chain ->
-            val original = chain.request()
-            val builder = original.newBuilder().header("Authorization", NetworkManager.authToken)
-            val request = builder.build()
-            chain.proceed(request)
-        }.build())
+        .client(OkHttpClient.Builder().addInterceptor(interceptor).build())
         .build().create(ChatBotAPI::class.java)
 
 interface ChatBotAPI {
@@ -51,13 +58,18 @@ interface ChatBotAPI {
     fun withdraw(@Field("username") username: String,
                  @Field("password") password: String
     ): Observable<Response<JsonObject>>
+
+    @FormUrlEncoded
+    @PATCH("/chatbot/my-info/")
+    fun changePassword(@Field("old_password") oldPassword: String,
+                       @Field("new_password") newPassword: String
+    ): Observable<Response<JsonObject>>
 }
 
 object NetworkManager {
-    var authToken = ""
-        set(value) {
-            field = "Token $value"
-        }
+    fun setAuthToken(token: String?) {
+        interceptor.authToken = if (token == null) "" else "Token $token"
+    }
 
     /**
      * Helper function of API methods.

--- a/app/src/main/java/com/cid/bot/Network.kt
+++ b/app/src/main/java/com/cid/bot/Network.kt
@@ -19,7 +19,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.*
 
 private val interceptor = object : Interceptor {
-    var authToken = ""
+    val authToken: String
+        get() = if (NetworkManager.authToken == null) "" else "Token ${NetworkManager.authToken}"
 
     override fun intercept(chain: Interceptor.Chain): okhttp3.Response {
         val original = chain.request()
@@ -50,6 +51,9 @@ interface ChatBotAPI {
                @Field("password") password: String
     ): Observable<Response<JsonObject>>
 
+    @POST("/chatbot/auth/signout/")
+    fun signOut(): Observable<Response<JsonObject>>
+
     @FormUrlEncoded
     @POST("/chatbot/auth/withdraw/")
     fun withdraw(@Field("username") username: String,
@@ -70,9 +74,7 @@ interface ChatBotAPI {
 }
 
 object NetworkManager {
-    fun setAuthToken(token: String?) {
-        interceptor.authToken = if (token == null) "" else "Token $token"
-    }
+    var authToken: String? = null
 
     /**
      * Helper function of API methods.

--- a/app/src/main/java/com/cid/bot/Network.kt
+++ b/app/src/main/java/com/cid/bot/Network.kt
@@ -45,6 +45,12 @@ interface ChatBotAPI {
     fun signIn(@Field("username") username: String,
                @Field("password") password: String
     ): Observable<Response<JsonObject>>
+
+    @FormUrlEncoded
+    @POST("/chatbot/auth/withdraw/")
+    fun withdraw(@Field("username") username: String,
+                 @Field("password") password: String
+    ): Observable<Response<JsonObject>>
 }
 
 object NetworkManager {

--- a/app/src/main/java/com/cid/bot/ProfileActivity.kt
+++ b/app/src/main/java/com/cid/bot/ProfileActivity.kt
@@ -1,0 +1,29 @@
+package com.cid.bot
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+
+class ProfileActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_profile)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_profile, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.mIsave -> {
+                // TODO: save user profile
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/java/com/cid/bot/ProfileActivity.kt
+++ b/app/src/main/java/com/cid/bot/ProfileActivity.kt
@@ -161,6 +161,8 @@ class ProfileActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        loadInfoTask?.dispose()
+        saveInfoTask?.dispose()
         changePasswordTask?.dispose()
         withdrawTask?.dispose()
         super.onDestroy()

--- a/app/src/main/java/com/cid/bot/ProfileActivity.kt
+++ b/app/src/main/java/com/cid/bot/ProfileActivity.kt
@@ -1,5 +1,6 @@
 package com.cid.bot
 
+import android.app.Activity
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
@@ -15,6 +16,29 @@ class ProfileActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
+
+        bTchangePassword.setOnClickListener {
+            val layout = layoutInflater.inflate(R.layout.dialog_change_password, null)
+
+            val dialog = AlertDialog.Builder(this)
+                    .setTitle("Change Password")
+                    .setMessage("Please input your current password and new password")
+                    .setView(layout)
+                    .setPositiveButton("Change", null)
+                    .setNegativeButton("Cancel", null)
+                    .show()
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener { _ ->
+                val currentPassword = layout.findViewById<EditText>(R.id.eTcurrentPassword).text.toString()
+                val newPassword = layout.findViewById<EditText>(R.id.eTnewPassword).text.toString()
+                val newPasswordConfirm = layout.findViewById<EditText>(R.id.eTnewPasswordConfirm).text.toString()
+                if (newPassword != newPasswordConfirm) {
+                    Toast.makeText(this, "New Passwords are not identical.", Toast.LENGTH_SHORT).show()
+                } else {
+                    tryChangePassword(currentPassword, newPassword)
+                    dialog.dismiss()
+                }
+            }
+        }
 
         bTwithdraw.setOnClickListener {
             val layout = layoutInflater.inflate(R.layout.dialog_withdraw, null)
@@ -33,12 +57,27 @@ class ProfileActivity : AppCompatActivity() {
         }
     }
 
+    private var changePasswordTask: Disposable? = null
+    private fun tryChangePassword(oldPassword: String, newPassword: String) {
+        if (changePasswordTask != null) return
+
+        changePasswordTask = NetworkManager.call(API.changePassword(oldPassword, newPassword), {
+            Toast.makeText(this, "Your password has been changed successfully.", Toast.LENGTH_SHORT).show()
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+        }, {
+            Toast.makeText(this, if ("error" in it) it["error"] else "Changing password did not finish successfully. Please try again.", Toast.LENGTH_SHORT).show()
+        }, {
+            changePasswordTask = null
+        })
+    }
+
     private var withdrawTask: Disposable? = null
     private fun tryWithdraw(username: String, password: String) {
         if (withdrawTask != null) return
 
         withdrawTask = NetworkManager.call(API.withdraw(username, password), {
-            Toast.makeText(this, "Your membership has been removed.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Your membership has been removed successfully.", Toast.LENGTH_SHORT).show()
             setResult(RESULT_CANCELED)
             finish()
         }, {
@@ -61,5 +100,11 @@ class ProfileActivity : AppCompatActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onDestroy() {
+        changePasswordTask?.dispose()
+        withdrawTask?.dispose()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/cid/bot/ProfileActivity.kt
+++ b/app/src/main/java/com/cid/bot/ProfileActivity.kt
@@ -2,14 +2,50 @@ package com.cid.bot
 
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.EditText
+import android.widget.Toast
+import io.reactivex.disposables.Disposable
+import kotlinx.android.synthetic.main.activity_profile.*
 
 class ProfileActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
+
+        bTwithdraw.setOnClickListener {
+            val layout = layoutInflater.inflate(R.layout.dialog_withdraw, null)
+
+            AlertDialog.Builder(this)
+                    .setTitle("Withdraw")
+                    .setMessage("Please input your username and password.")
+                    .setView(layout)
+                    .setPositiveButton("Withdraw") { _, _ ->
+                        val username = layout.findViewById<EditText>(R.id.eTusername).text.toString()
+                        val password = layout.findViewById<EditText>(R.id.eTpassword).text.toString()
+                        tryWithdraw(username, password)
+                    }
+                    .setNegativeButton("Cancel", null)
+                    .show()
+        }
+    }
+
+    private var withdrawTask: Disposable? = null
+    private fun tryWithdraw(username: String, password: String) {
+        if (withdrawTask != null) return
+
+        withdrawTask = NetworkManager.call(API.withdraw(username, password), {
+            Toast.makeText(this, "Your membership has been removed.", Toast.LENGTH_SHORT).show()
+            setResult(RESULT_CANCELED)
+            finish()
+        }, {
+            Toast.makeText(this, "Withdrawal did not finish successfully. Please try again.", Toast.LENGTH_SHORT).show()
+        }, {
+            withdrawTask = null
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/com/cid/bot/ProfileActivity.kt
+++ b/app/src/main/java/com/cid/bot/ProfileActivity.kt
@@ -73,6 +73,8 @@ class ProfileActivity : AppCompatActivity() {
 
         loadInfoTask = NetworkManager.call(API.loadMyInfo(), {
             refresh(it)
+            sCautoSignIn.isChecked = getSharedPreferences(getString(R.string.pref_name_sign), 0).getBoolean(getString(R.string.pref_key_auto_sign_in), false)
+            if (!sCautoSignIn.isChecked) sCautoSignIn.isEnabled = false
         }, {
             Toast.makeText(this, "Could not load profile temporarily. Please try later.", Toast.LENGTH_SHORT).show()
             finish()
@@ -98,8 +100,16 @@ class ProfileActivity : AppCompatActivity() {
         saveInfoTask = NetworkManager.call(API.saveMyInfo(muser), {
             Toast.makeText(this, "Your profile has been modified successfully.", Toast.LENGTH_SHORT).show();
             refresh(it)
+            with (getSharedPreferences(getString(R.string.pref_name_sign), 0).edit()) {
+                putBoolean(getString(R.string.pref_key_auto_sign_in), sCautoSignIn.isChecked)
+                if (sCautoSignIn.isChecked)
+                    putString(getString(R.string.pref_key_token), NetworkManager.authToken)
+                else
+                    sCautoSignIn.isEnabled = false
+                apply()
+            }
         }, {
-            Toast.makeText(this, "Please try later.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "Please try later.", Toast.LENGTH_SHORT).show()
         }, {
             saveInfoTask = null
         })

--- a/app/src/main/java/com/cid/bot/SignActivity.kt
+++ b/app/src/main/java/com/cid/bot/SignActivity.kt
@@ -119,7 +119,7 @@ class SignActivity : AppCompatActivity() {
             return
         }
 
-        NetworkManager.call(API.signUp(username, password), {
+        signUpTask = NetworkManager.call(API.signUp(username, password), {
             Toast.makeText(this, "You have been signed up for our membership.\nPlease sign in to use our service.", Toast.LENGTH_LONG).show()
             eTusername.setText("")
             eTpassword.setText("")

--- a/app/src/main/java/com/cid/bot/SignActivity.kt
+++ b/app/src/main/java/com/cid/bot/SignActivity.kt
@@ -26,6 +26,7 @@ class SignActivity : AppCompatActivity() {
 
         supportActionBar?.title = Mode.SIGN_IN.string
         setResult(Activity.RESULT_CANCELED)
+        NetworkManager.setAuthToken(null)
 
         pref = getSharedPreferences(getString(R.string.pref_name_sign), 0)
         eTusername.setText(pref.getString(getString(R.string.pref_key_username), ""))
@@ -94,7 +95,7 @@ class SignActivity : AppCompatActivity() {
 
         signInTask = NetworkManager.call(API.signIn(username, password), {
             val token = it["token"].asString
-            NetworkManager.authToken = token
+            NetworkManager.setAuthToken(token)
 
             setResult(RESULT_OK)
             finish()
@@ -125,8 +126,7 @@ class SignActivity : AppCompatActivity() {
             eTpasswordConfirm.setText("")
             changeMode(Mode.SIGN_IN)
         }, {
-            // TODO: set errors on EditTexts (Currently the backend does not response error body)
-            Toast.makeText(this, "Shit... Sorry, your username or password seems to be invalid.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, if ("error" in it) it["error"] else "Please try again.", Toast.LENGTH_SHORT).show()
         }, {
             signUpTask = null
         })

--- a/app/src/main/java/com/cid/bot/models.kt
+++ b/app/src/main/java/com/cid/bot/models.kt
@@ -1,0 +1,3 @@
+package com.cid.bot
+
+data class Muser(val id: Int?, val username: String, val gender: Int, val birthdate: String?)

--- a/app/src/main/res/drawable/ic_save_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_save_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -60,7 +60,7 @@
                     android:layout_marginTop="8dp"
                     android:ems="8"
                     android:hint="yyyy-MM-dd"
-                    android:inputType="number"
+                    android:inputType="date"
                     android:singleLine="true"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -20,6 +20,30 @@
             android:layout_height="match_parent">
 
             <android.support.constraint.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintLayout2">
+
+                <Switch
+                    android:id="@+id/sCautoSignIn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="8dp"
+                    android:text="Auto Sign In"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:checked="true" />
+            </android.support.constraint.ConstraintLayout>
+
+            <android.support.constraint.ConstraintLayout
                 android:id="@+id/constraintLayout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -28,15 +52,14 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <EditText
-                    android:id="@+id/eTage"
+                    android:id="@+id/eTbirthdate"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"
                     android:layout_marginEnd="8dp"
                     android:layout_marginTop="8dp"
-                    android:ems="4"
-                    android:gravity="end"
-                    android:hint="age"
+                    android:ems="8"
+                    android:hint="yyyy-MM-dd"
                     android:inputType="number"
                     android:singleLine="true"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -44,19 +67,20 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/tVage"
+                    android:id="@+id/tVbirthdate"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"
                     android:layout_marginStart="16dp"
                     android:layout_marginTop="8dp"
-                    android:text="Age"
+                    android:text="Date of Birth"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
             </android.support.constraint.ConstraintLayout>
 
             <android.support.constraint.ConstraintLayout
+                android:id="@+id/constraintLayout2"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="8dp"
@@ -117,4 +141,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/bTchangePassword" />
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ProfileActivity">
+
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/bTchangePassword"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/constraintLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <EditText
+                    android:id="@+id/eTage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginTop="8dp"
+                    android:ems="4"
+                    android:gravity="end"
+                    android:hint="age"
+                    android:inputType="number"
+                    android:singleLine="true"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tVage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="8dp"
+                    android:text="Age"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </android.support.constraint.ConstraintLayout>
+
+            <android.support.constraint.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintLayout">
+
+                <TextView
+                    android:id="@+id/tVgender"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="8dp"
+                    android:text="Gender"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Spinner
+                    android:id="@+id/sPgender"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginTop="8dp"
+                    android:entries="@array/genderTypes"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </android.support.constraint.ConstraintLayout>
+
+        </android.support.constraint.ConstraintLayout>
+    </ScrollView>
+
+    <Button
+        android:id="@+id/bTchangePassword"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginStart="8dp"
+        android:text="Change Password"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/bTwithdraw"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/bTwithdraw"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="4dp"
+        android:text="Withdraw"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/bTchangePassword" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign.xml
+++ b/app/src/main/res/layout/activity_sign.xml
@@ -38,12 +38,26 @@
         android:id="@+id/cBautoSignIn"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="4dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:text="Auto Sign In"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/cBsaveUsername"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tILpasswordConfirm" />
+
+    <CheckBox
+        android:id="@+id/cBsaveUsername"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="8dp"
+        android:text="Save Username"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/cBautoSignIn"
         app:layout_constraintTop_toBottomOf="@+id/tILpasswordConfirm" />
 
     <android.support.design.widget.TextInputLayout

--- a/app/src/main/res/layout/dialog_change_password.xml
+++ b/app/src/main/res/layout/dialog_change_password.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/tILcurrentPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/eTcurrentPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Current Password"
+            android:inputType="textPassword" />
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/tILnewPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tILcurrentPassword">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/eTnewPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="New Password"
+            android:inputType="textPassword" />
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/tILnewPasswordConfirm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tILnewPassword">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/eTnewPasswordConfirm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="New Password Confirm"
+            android:inputType="textPassword" />
+
+    </android.support.design.widget.TextInputLayout>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_withdraw.xml
+++ b/app/src/main/res/layout/dialog_withdraw.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/textInputLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/eTusername"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Username"
+            android:inputType="text" />
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/tILpassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textInputLayout2">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/eTpassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Password"
+            android:inputType="textPassword" />
+
+    </android.support.design.widget.TextInputLayout>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/menu_chat.xml
+++ b/app/src/main/res/menu/menu_chat.xml
@@ -4,4 +4,10 @@
     <item
         android:id="@+id/mIprofile"
         android:title="Profile" />
+    <item
+        android:id="@+id/mIsignOut"
+        android:title="Sign Out" />
+    <item
+        android:id="@+id/mIexit"
+        android:title="Exit" />
 </menu>

--- a/app/src/main/res/menu/menu_chat.xml
+++ b/app/src/main/res/menu/menu_chat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/mIprofile"
+        android:title="Profile" />
+</menu>

--- a/app/src/main/res/menu/menu_profile.xml
+++ b/app/src/main/res/menu/menu_profile.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/mIsave"
+        android:icon="@drawable/ic_save_black_24dp"
+        android:title="Save"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,10 @@
     <string name="pref_key_username">username</string>
     <string name="pref_key_password">password</string>
     <string name="pref_name_sign">sign</string>
+
+    <string-array name="genderTypes">
+        <item>Male</item>
+        <item>Female</item>
+        <item>Others</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="pref_name_sign">sign</string>
 
     <string-array name="genderTypes">
+        <item>Others</item>
         <item>Male</item>
         <item>Female</item>
-        <item>Others</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,11 @@
 <resources>
     <string name="app_name">μBot</string>
 
-    <string name="pref_key_auto_sign_in">auto_sign_in</string>
-    <string name="pref_key_username">username</string>
-    <string name="pref_key_password">password</string>
     <string name="pref_name_sign">sign</string>
+    <string name="pref_key_auto_sign_in">auto_sign_in</string>
+    <string name="pref_key_token">token</string>
+    <string name="pref_key_save_username">save_username</string>
+    <string name="pref_key_username">username</string>
 
     <string-array name="genderTypes">
         <item>Others</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="colorButtonNormal">@color/colorAccent</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
 </resources>


### PR DESCRIPTION
# ChatActivity Menu
![image](https://user-images.githubusercontent.com/24453019/46871531-aaac2b80-ce6c-11e8-8d89-4e3f8acd33dc.png)
ChatActivity에서 위와 같이 세가지의 메뉴가 생겼습니다.
- **Profile**: 유저의 정보를 수정하거나 탈퇴할 수 있습니다.
- **Sign Out**: 사인아웃을 하고 사인인 페이지를 띄웁니다.
- **Exit**: 앱을 종료합니다.

# ProfileActivity
ChatActivity 메뉴에서 Profile항목을 선택하면 나오는 Activity입니다.
![image](https://user-images.githubusercontent.com/24453019/46871639-ecd56d00-ce6c-11e8-9f94-b23fd1d3a69b.png)
- **Date of Birth**: 생년월일을 설정할 수 있습니다. 현재는 단순히 yyyy-MM-dd 형식으로 입력해야 하지만 조만간 Date Picker를 사용할 예정입니다.
- **Gender**: 성별을 설정할 수 있습니다. Others, Male, Female 중에 고를 수 있습니다.
- **Auto Sign In**: 자동 사인인을 해제할 수 있습니다. 자동 사인인을 체크하지 않고 사인인 했거나 사인인을 해제한 상태로 저장했을 경우에는 이곳에서 자동 사인인을 On으로 설정할 수는 없고 사인인 페이지에서 사인인을 하는 것과 동시에 자동 사인인을 On으로 설정해야만 합니다.
- **Change Password**: 패스워드를 바꿀 수 있습니다. 현재 패스워드와 새로운 패스워드를 입력하는 대화상자가 열립니다.
![image](https://user-images.githubusercontent.com/24453019/46871858-738a4a00-ce6d-11e8-951c-6041e6ccf5b1.png)
성공적으로 변경했을 경우에는 자동으로 사인인 페이지로 돌아가게 됩니다.
- **Withdraw**: 회원탈퇴를 할 수 있습니다. 현재 유저네임과 패스워드를 입력하는 대화상자가 열립니다.
![image](https://user-images.githubusercontent.com/24453019/46871900-9583cc80-ce6d-11e8-8d3a-7a7daa85ff0d.png)
성공적으로 탈퇴가 되었을 경우에는 자동으로 사인인 페이지로 돌아가게 됩니다.

![image](https://user-images.githubusercontent.com/24453019/46871929-a6344280-ce6d-11e8-9906-f47f52fba330.png)
우측 상단의 저장 버튼을 누르면 변경된 정보들이 서버에 저장됩니다.

# SignActivity
![image](https://user-images.githubusercontent.com/24453019/46872058-180c8c00-ce6e-11e8-981e-dbc401a3616a.png)
두가지 옵션이 있습니다.
- **Auto Sign In**: 이 설정을 On으로 했을 시에는 ChatActivity에서 Sign Out 메뉴를 클릭하거나 비밀번호를 변경하기 전까지 자동으로 사인인이 진행됩니다. ChatActivity에서 뒤로 버튼을 눌러 앱을 종료하거나 Exit 메뉴를 사용했을 때에도 유지됩니다.
![image](https://user-images.githubusercontent.com/24453019/46872236-88b3a880-ce6e-11e8-927f-70920a3fba6f.png)
On 설정 후 앱을 재시작하면 위와 같은 토스트가 뜨며 바로 ChatActivity로 이동하게 됩니다.
- **Save Username**: 이 설정을 On으로 했을 시, 유저네임을 저장하고 사인인 페이지가 켜졌을 때 자동으로 입력칸을 채웁니다.
